### PR TITLE
Updated bower dependency versions for: i18next, i18next-xhr-backend

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,8 +32,8 @@
     "tests"
   ],
   "dependencies": {
-    "i18next": "^3.3.1",
-    "i18next-xhr-backend": "^0.6.0",
+    "i18next": "^8.4.0",
+    "i18next-xhr-backend": "^1.4.1",
     "sprintf": "^1.0.3"
   }
 }


### PR DESCRIPTION
https://github.com/webduct/i18n-client/issues/1

This PR is to merge the forked webduct/i18n-client back into islandlinux